### PR TITLE
Update dependencies

### DIFF
--- a/admittance_demo/admittance_controller.repos
+++ b/admittance_demo/admittance_controller.repos
@@ -36,8 +36,8 @@ repositories:
 
   Universal_Robots_ROS2_Driver:
     type: git
-    url: https://github.com/fmauch/Universal_Robots_ROS2_Driver.git
-    version: update_ros2_controllers_api
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+    version: main
 
   ur_msgs:
     type: git

--- a/admittance_demo/admittance_controller.repos
+++ b/admittance_demo/admittance_controller.repos
@@ -1,8 +1,8 @@
 repositories:
   control_msgs:
     type: git
-    url: https://github.com/pac48/control_msgs.git
-    version: add-admittance-controller
+    url: https://github.com/ros-controls/control_msgs.git
+    version: humble
 
   control_toolbox:
     type: git

--- a/admittance_demo/admittance_controller.repos
+++ b/admittance_demo/admittance_controller.repos
@@ -9,19 +9,9 @@ repositories:
     url: https://github.com/ros-controls/control_toolbox.git
     verstion: ros2-master
 
-  generate_parameter_library:
-    type: git
-    url: https://github.com/picknikrobotics/generate_parameter_library.git
-    version: main
-
   kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
-    version: master
-
-  ros2_control:
-    type: git
-    url: https://github.com/ros-controls/ros2_control.git
     version: master
 
   ros2_control_demos:
@@ -46,8 +36,8 @@ repositories:
 
   Universal_Robots_ROS2_Driver:
     type: git
-    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
-    version: 2.2.3
+    url: https://github.com/fmauch/Universal_Robots_ROS2_Driver.git
+    version: update_ros2_controllers_api
 
   ur_msgs:
     type: git

--- a/admittance_demo/using_admittance_controller.md
+++ b/admittance_demo/using_admittance_controller.md
@@ -11,7 +11,7 @@ This manual targets ROS2 rolling.
    ```
 1. Clone this moveit2 repository and import the `moveit2/moveit2.repos` file:
    ```
-   git clone https://github.com/pac48/moveit2.git -b pr-support-chained-controllers
+   git clone https://github.com/ros-planning/moveit2.git -b main
    vcs import < "moveit2/moveit2.repos"
    ```
 1. Checkout the repositories from `admittance_controller.repos` file:


### PR DESCRIPTION
@pac48 I updated the dependencies that are required to be installed for the demo:
- Remove `generate_parameter_library` and `ros2_control`: both are released with the required features by now
- Change  Universal_Robots_ROS2_Driver to a fork that supports the new ros2_controller param API
- Switch to MoveIt2 main repository since the support for chainable controller PR got merged